### PR TITLE
Disable endpoint validation option and change default redirect URI

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -17,6 +17,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 partial class Build : NukeBuild,
     IHasGitRepository,
     IHasVersioning,
+    IClean,
     IRestore,
     IFormat,
     ICompile,
@@ -35,21 +36,10 @@ partial class Build : NukeBuild,
     readonly Solution Solution;
     Solution IHasSolution.Solution => Solution;
 
-    Target Clean => _ => _
-        .Before<IRestore>()
-        .Executes(() =>
-        {
-            DotNetClean(_ => _
-                .SetProject(Solution));
-
-            EnsureCleanDirectory(FromComponent<IHasArtifacts>().ArtifactsDirectory);
-        });
-
     public IEnumerable<string> ExcludedFormatPaths => Enumerable.Empty<string>();
 
     Target ICompile.Compile => _ => _
         .Inherit<ICompile>()
-        .DependsOn(Clean)
         .DependsOn<IFormat>(x => x.VerifyFormat);
 
     Configure<DotNetPublishSettings> ICompile.PublishSettings => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
     <PackageReference Include="Nuke.Common" Version="6.3.0" />
-    <PackageReference Include="Xerris.Nuke.Components" Version="0.2.1" />
+    <PackageReference Include="Xerris.Nuke.Components" Version="0.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tool/AuthenticateCommand.cs
+++ b/src/Tool/AuthenticateCommand.cs
@@ -116,13 +116,13 @@ public class AuthenticateCommand : RootCommand
 
         var options = new OidcClientOptions
         {
-            Policy =policy,
+            Policy = policy,
             Authority = authority,
             ClientId = clientId,
             FilterClaims = false,
             LoadProfile = true,
-            RedirectUri = $"http://127.0.0.1:{port}",
-            PostLogoutRedirectUri = $"http://127.0.0.1:{port}",
+            RedirectUri = $"http://localhost:{port}",
+            PostLogoutRedirectUri = $"http://localhost:{port}",
             Scope = scope,
             Browser = new SystemBrowser(port.Value)
         };

--- a/src/Tool/AuthenticateCommand.cs
+++ b/src/Tool/AuthenticateCommand.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using IdentityModel.Client;
 using IdentityModel.OidcClient;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace OidcCli;
 
@@ -70,24 +71,52 @@ public class AuthenticateCommand : RootCommand
 
         AddOption(diagnosticsOption);
 
-        this.SetHandler(async (authority, clientId, scope, port, audience, diagnostics) =>
-        {
-            using var cancellationTokenSource = new CancellationTokenSource();
+        var disableEndpointValidationOption = new Option<bool>(
+            name: "--disableEndpointValidation",
+            description: "Disable validation of authorization, token, and userinfo endpoints in the providers OpenID " +
+                         "configuration (optional)",
+            getDefaultValue: () => false);
 
-            await AuthenticateAsync(authority, clientId, scope, port, audience, diagnostics,
-                cancellationTokenSource.Token).ConfigureAwait(false);
+        AddOption(disableEndpointValidationOption);
 
-        }, authorityOption, clientIdOption, scopeOption, portOption, audienceOption, diagnosticsOption);
+        this.SetHandler(async (authority, clientId, scope, port, audience, diagnostics, disableEndpointValidation) =>
+            {
+                using var cancellationTokenSource = new CancellationTokenSource();
+
+                await AuthenticateAsync(authority, clientId, scope, port, audience, diagnostics,
+                    disableEndpointValidation,
+                    cancellationTokenSource.Token).ConfigureAwait(false);
+
+            }, authorityOption, clientIdOption, scopeOption, portOption, audienceOption, diagnosticsOption,
+            disableEndpointValidationOption);
     }
 
     private async Task AuthenticateAsync(string authority, string clientId, string scope, int? port = null,
-        string? audience = null, bool diagnostics = false, CancellationToken cancellationToken = default)
+        string? audience = null, bool diagnostics = false, bool disableEndpointValidation = false, CancellationToken cancellationToken = default)
     {
         port ??= GetRandomUnusedPort();
 
+        var policy = new Policy
+        {
+            RequireAccessTokenHash = false
+        };
+
+        if (disableEndpointValidation)
+        {
+            policy.Discovery = new DiscoveryPolicy
+            {
+                EndpointValidationExcludeList = new List<string>
+                {
+                    "authorization_endpoint",
+                    "token_endpoint",
+                    "userinfo_endpoint"
+                }
+            };
+        }
+
         var options = new OidcClientOptions
         {
-            Policy = new Policy { RequireAccessTokenHash = false },
+            Policy =policy,
             Authority = authority,
             ClientId = clientId,
             FilterClaims = false,

--- a/src/Tool/Xerris.OidcCli.Tool.csproj
+++ b/src/Tool/Xerris.OidcCli.Tool.csproj
@@ -14,10 +14,11 @@
     <Authors>Xerris Inc.</Authors>
     <Description>OpenID Connect &amp; OAuth 2.0 CLI client</Description>
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer</PackageTags>
-    <PackageProjectUrl>https://github.com/xerris/OidcCli/</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/xerris/oidc-cli/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +27,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="IdentityModel.OidcClient" Version="5.0.2" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Addresses some quirks of using this tool with "quirky" authorities (Cognito):

- Allows endpoint validation to be disabled when validating the OIDC discovery document. This handles the case where the authority does not have the same base URLs for their authorization, token, and userinfo endpoints
- Changes the redirect URI used by the app from the loopback IP (127.0.0.1) to `localhost`. In this case, Cognito only allows `localhost` URLs to be used without https. This should not affect other providers, but is a breaking change since redirect URLs that may already be configured on the authority will need to be changed as well.